### PR TITLE
explicitly use Swift.print() to resolve ambiguity

### DIFF
--- a/spo.py
+++ b/spo.py
@@ -37,7 +37,7 @@ def _swift_po(debugger, expression, ctx, result, _):
             return
 
     # Finally, use Swift's print() to avoid leaked objects.
-    err = frame.EvaluateExpression("print({})".format(expression))
+    err = frame.EvaluateExpression("Swift.print({})".format(expression))
     if err.error.fail:
         print(err.error.description, file=result)
 


### PR DESCRIPTION
Use `Swift.print()`. This helps when there's an instance `print()` (as seen in AppKit eg. NSDocument.print())


fixes:
```
error: use of 'print' refers to instance method rather than global function 'print(_:separator:terminator:)' in module 'Swift'
```